### PR TITLE
GitHub Labels Syncing

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,8 @@
+# GitHub Labels Syncing
+
+As discussed, we're adding label syncing to help us keep labels across our many repos in sync.
+* Adding a new label to a specific repo replicates it to other repos
+* Modifying a new label in the originating repo updates it everywhere
+* Deleting a label deletes it in all repos
+
+For testing, I recommend setting up a few empty repos in your private GitHub account so that you can freely play without risking the mass destruction of our labels.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,8 +1,8 @@
 # GitHub Labels Syncing
 
-As discussed, we're adding label syncing to help us keep labels across our many repos in sync.
+As discussed, we're adding label syncing to help us keep labels consistent across our many repos in sync.
 * Adding a new label to a specific repo replicates it to other repos
-* Modifying a new label in the originating repo updates it everywhere
+* Modifying a label in the originating repo updates it everywhere
 * Deleting a label deletes it in all repos
 
 For testing, I recommend setting up a few empty repos in your private GitHub account so that you can freely play without risking the mass destruction of our labels.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Aside from adding the markdown table, the endpoint also alters the parent issue'
 
 ![screenshot](https://p-NBF5xJ28.t3.n0.cdn.getcloudapp.com/items/2Nulq7qB/0e966b93-a83f-45c5-960c-2559ab166dea.jpeg?v=0bda7154be85f18627a165a230bfc31a)
 
+### 2. `github/replicate-labels?owner={REPO_OWNER}&repos={SYNCED_REPOS}`
+
+The `github/replicate-labels` endpoint disseminates labels across our repos from a single central repo. Whenever you create a label in a repo where the webhook is running, it will sync adds/edits/deletions of that label to other labels specified in the webhook.
+
+Arguments:
+* `REPO_OWNER` - The organization that owns the repo
+* `SYNCED_REPOS` - A JSON array of repos to where the label change will be synced
+
 ## Quality
 
 At this point, the project doesn't meet all the best practices of Integrations as it's not customer-facing. This said, all new changes are expected to improve the status quo. If we touch sub-par code and don't have time to improve it, we should create issues to track the technical debt

--- a/src/gitHub/gitHub.module.ts
+++ b/src/gitHub/gitHub.module.ts
@@ -9,10 +9,11 @@ import {
     ENDPOINT_PATH as LinkChildIssuePath,
 } from './gitHubLinkChildIssue.controller'
 import { GitHubLinkChildIssueTextService } from './gitHubLinkChildIssueText.service'
+import { ReplicateLabelsController, ENDPOINT_PATH as ReplicateLabelsPath, } from './replicateLabels.controller'
 
 @Module({
     imports: [ConfigModule.forRoot()],
-    controllers: [GitHubLinkChildIssueController],
+    controllers: [GitHubLinkChildIssueController, ReplicateLabelsController],
     providers: [
         GitHubConfigurationService,
         AppConfigurationService,
@@ -29,6 +30,11 @@ export class GitHubReportModule {
             .apply(RawBodyMiddleware)
             .forRoutes({
                 path: `/${LinkChildIssuePath}`,
+                method: RequestMethod.ALL,
+            })
+            .apply(RawBodyMiddleware)
+            .forRoutes({
+                path: `/${ReplicateLabelsPath}`,
                 method: RequestMethod.ALL,
             })
             .apply(JsonBodyMiddleware)

--- a/src/gitHub/gitHubLabel.ts
+++ b/src/gitHub/gitHubLabel.ts
@@ -1,3 +1,4 @@
 export type GitHubLabel = {
     name: string
+    color: string
 }

--- a/src/gitHub/replicateLabels.controller.ts
+++ b/src/gitHub/replicateLabels.controller.ts
@@ -1,0 +1,107 @@
+import { Controller, Request, Headers, Post, HttpException, Param } from '@nestjs/common'
+import { Octokit } from '@octokit/rest'
+import { createHmac } from 'crypto'
+import { GitHubAction } from './gitHubAction'
+import { GitHubConfigurationService } from './gitHubConfiguration.service'
+import { GitHubLabel } from './gitHubLabel'
+
+export const ENDPOINT_PATH = 'github/replicate-labels'
+export const GITHUB_SIGNATURE_HEADER_KEY = 'x-hub-signature-256'
+
+type GitHubReplicateLabelsRequest = {
+    action: GitHubAction
+    label: GitHubLabel
+    changes: {
+        name: {
+            from: string
+        }
+    }
+}
+
+
+@Controller(ENDPOINT_PATH)
+export class ReplicateLabelsController {
+    client: Octokit
+    constructor(
+        private readonly configuration: GitHubConfigurationService,
+    ) {
+        this.client = new Octokit({
+            auth: configuration.getConfiguration().token,
+        })
+    }
+
+    @Post()
+    async get(
+        @Request() request: { body: Buffer, query: { owner: string, repos: string } },
+        @Headers() headers: Record<string, string>
+    ): Promise<string> {
+        const { body, query } = request
+        const { owner, repos } = query
+        const reposDeserialized = JSON.parse(repos)
+        const bodyAsString = body.toString()
+        const secret = this.configuration.getConfiguration().gitHubRequestVerificationSecret
+        const digest = createHmac('sha256', secret)
+            .update(bodyAsString)
+            .digest('hex')
+
+        if (`sha256=${digest}` !== headers[GITHUB_SIGNATURE_HEADER_KEY]) {
+            throw new HttpException('Digest does not match', 401)
+        }
+
+        const { label, action, changes } = JSON.parse(bodyAsString) as GitHubReplicateLabelsRequest
+
+        const hasLabel = async (repo: string, labelName: string): Promise<boolean> => {
+            try {
+                return !!(await this.client.issues.getLabel({
+                    name: labelName,
+                    repo,
+                    owner,
+                })).data
+            } catch (error) {
+                // no label
+                return false
+            }
+        }
+
+        if (action === 'deleted') {
+            await Promise.all(reposDeserialized.map(async x => {
+                if(!await hasLabel(x, label.name)) {
+                    return;
+                }
+
+                await this.client.issues.deleteLabel({
+                    repo: x,
+                    name: label.name,
+                    owner,
+                })
+            }))
+        }
+
+        else if (action === 'created') {
+            await Promise.all(reposDeserialized.map(x => this.client.issues.createLabel({
+                repo: x,
+                name: label.name,
+                owner,
+                color: label.color
+            })))
+        }
+
+        else if (action === 'edited') {
+            await Promise.all(reposDeserialized.map(async x => {
+                if (!await hasLabel(x, changes.name.from)) {
+                    return;
+                }
+                
+                await this.client.issues.updateLabel({
+                    repo: x,
+                    name: changes.name.from,
+                    new_name: label.name,
+                    owner,
+                    color: label.color
+                })
+            }))
+        }
+
+        return 'Ok'
+    }
+}


### PR DESCRIPTION
# GitHub Labels Syncing

As discussed, we're adding label syncing to help us keep labels consistent across our many repos in sync.
* Adding a new label to a specific repo replicates it to other repos
* Modifying a label in the originating repo updates it everywhere
* Deleting a label deletes it in all repos

For testing, I recommend setting up a few empty repos in your private GitHub account so that you can freely play without risking the mass destruction of our labels.